### PR TITLE
Proc forking start

### DIFF
--- a/daemon/callbacks.go
+++ b/daemon/callbacks.go
@@ -11,6 +11,28 @@ import (
 	"github.com/an-prata/webby/server"
 )
 
+// The only argument that will be given to the callbacks for deamon commands.
+// Each callback may interperet this differently, for example, the restart
+// command ignores its argument, but log level commands will interperet this to
+// be a log level.
+type DaemonCommandArg uint8
+
+// The success/failure of a daemon command. This will appear as a single byte
+// response to any client commands indicating the success or failure of a
+// command.
+type DaemonCommandSuccess uint8
+
+// Type alias for the function signature of a daemon command callback.
+type DaemonCommandCallback func(DaemonCommandArg) error
+
+const (
+	// The daemon command completed successfuly.
+	Success DaemonCommandSuccess = iota
+
+	// The daemon command failed.
+	Failure
+)
+
 // Represents a signal originating at a daemon command and sent through a
 // channel by the reload callback.
 type ReloadSignal struct{}

--- a/daemon/commands.go
+++ b/daemon/commands.go
@@ -6,9 +6,139 @@ package daemon
 
 import (
 	"net"
+	"os"
+	"os/user"
+	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/an-prata/webby/logger"
 )
+
+// Represents possible commands from client connections.
+type DaemonCommand string
+
+const (
+	// The `None` variant here shouldn't really be used.
+	None DaemonCommand = ""
+
+	// Included here for completeness, this command should not have a callback that
+	// sends a daemon comand as it is intended to be the start of the daemon
+	// process.
+	Daemon = "daemon"
+
+	// Included for the same reasons as `Daemon` and should also not have a
+	// callback. Starts the daemon process much like `Daemon` but forks the
+	// process into the background.
+	Start = "start"
+
+	// Restarts the HTTP server and rescans directories. Useful when edits have
+	// been made to the website contents. Should ignore the passed in argument.
+	Restart = "restart"
+
+	// Reloads the configuration file and then restarts.
+	Reload = "reload"
+
+	// Stops the current daemon.
+	Stop = "stop"
+
+	// Sets the log level for recording logs to file. Should interperet its
+	// argument to be the desired log level.
+	LogRecord = "log-record"
+
+	// Sets the log level for printing to standard out. As a daemonized program
+	// this will be what shows up when checking the output of `# systemctl status
+	// webby`. Should interperet its argument to be the desired log level.
+	LogPrint = "log-print"
+)
+
+const maximumSocketChecks = 10
+
+// Starts a daemon process and forks it.
+func StartForkedDaemon(log *logger.Log) {
+	user, err := user.Current()
+
+	if err != nil {
+		log.LogErr("Could not get information on the current user")
+		return
+	}
+
+	// Base-10 and 32 bit.
+	uid, err := strconv.ParseUint(user.Uid, 10, 32)
+
+	if err != nil {
+		log.LogErr("Could not parse UID from '" + user.Uid + "'")
+		return
+	}
+
+	gid, err := strconv.ParseInt(user.Gid, 10, 32)
+
+	if err != nil {
+		log.LogErr("Could not parse GID from '" + user.Gid + "'")
+		return
+	}
+
+	cred := syscall.Credential{
+		Uid:         uint32(uid),
+		Gid:         uint32(gid),
+		Groups:      []uint32{},
+		NoSetGroups: true,
+	}
+
+	sysproc := syscall.SysProcAttr{
+		Credential: &cred,
+		Noctty:     true,
+	}
+
+	attr := os.ProcAttr{
+		Dir: ".",
+		Env: os.Environ(),
+		Files: []*os.File{
+			os.Stdin,
+			nil,
+			nil,
+		},
+		Sys: &sysproc,
+	}
+
+	log.LogInfo("Starting process...")
+
+	proc, err := os.StartProcess(
+		os.Args[0],
+		[]string{os.Args[0], "-" + Daemon},
+		&attr,
+	)
+
+	if err != nil {
+		log.LogErr("Failed to start system process")
+		return
+	}
+
+	// Detatch new process from parent.
+	log.LogInfo("Detatching process from parent...")
+	err = proc.Release()
+
+	if err != nil {
+		log.LogErr("Could not detatch process")
+		return
+	}
+
+	log.LogInfo("Waiting for webby daemon process to respond...")
+
+	for i := 0; i < maximumSocketChecks; i++ {
+		socket, err := net.Dial("unix", SocketPath)
+
+		if err == nil {
+			socket.Close()
+			log.LogInfo("Started webby!")
+			return
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+	log.LogErr("Could create a process but webby failed to start, you may need elevated permissions")
+}
 
 // Sends a command, using the given command line argument, to the daemon using
 // the provided socket.

--- a/daemon/listener.go
+++ b/daemon/listener.go
@@ -16,60 +16,6 @@ import (
 // The path of the Unix Domain Socket created by webby for accepting commands.
 const SocketPath = "/run/webby.sock"
 
-// Represents possible commands from client connections.
-type DaemonCommand string
-
-const (
-	// The `None` variant here shouldn't really be used.
-	None DaemonCommand = ""
-
-	// Included here for completeness, this command should not have a callback that
-	// sends a daemon comand as it is intended to be the start of the daemon
-	// process.
-	Daemon = "daemon"
-
-	// Restarts the HTTP server and rescans directories. Useful when edits have
-	// been made to the website contents. Should ignore the passed in argument.
-	Restart = "restart"
-
-	// Reloads the configuration file and then restarts.
-	Reload = "reload"
-
-	// Stops the current daemon.
-	Stop = "stop"
-
-	// Sets the log level for recording logs to file. Should interperet its
-	// argument to be the desired log level.
-	LogRecord = "log-record"
-
-	// Sets the log level for printing to standard out. As a daemonized program
-	// this will be what shows up when checking the output of `# systemctl status
-	// webby`. Should interperet its argument to be the desired log level.
-	LogPrint = "log-print"
-)
-
-// The only argument that will be given to the callbacks for deamon commands.
-// Each callback may interperet this differently, for example, the restart
-// command ignores its argument, but log level commands will interperet this to
-// be a log level.
-type DaemonCommandArg uint8
-
-// The success/failure of a daemon command. This will appear as a single byte
-// response to any client commands indicating the success or failure of a
-// command.
-type DaemonCommandSuccess uint8
-
-// Type alias for the function signature of a daemon command callback.
-type DaemonCommandCallback func(DaemonCommandArg) error
-
-const (
-	// The daemon command completed successfuly.
-	Success DaemonCommandSuccess = iota
-
-	// The daemon command failed.
-	Failure
-)
-
 type DaemonListener struct {
 	// The Unix socket by which to listen for incoming commands/requests.
 	socket net.Listener

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 
 func main() {
 	var daemonProc bool
+	var start bool
 	var reload bool
 	var restart bool
 	var stop bool
@@ -21,6 +22,7 @@ func main() {
 	var logPrint string
 
 	flag.BoolVar(&daemonProc, daemon.Daemon, false, "runs the webby server daemon process rather than behaving like a control application")
+	flag.BoolVar(&start, daemon.Start, false, "starts the daemon in a new process and forks it into the background")
 	flag.BoolVar(&reload, daemon.Reload, false, "reloads the configuration file and then restarts, this will reset log levels")
 	flag.BoolVar(&restart, daemon.Restart, false, "restarts the webby HTTP server, rescanning directories")
 	flag.BoolVar(&stop, daemon.Stop, false, "stops the running daemon")
@@ -35,6 +37,12 @@ func main() {
 	}
 
 	log, _ := logger.NewLog(logger.All, logger.None, "")
+
+	if start {
+		daemon.StartForkedDaemon(&log)
+		return
+	}
+
 	socket, err := net.Dial("unix", daemon.SocketPath)
 
 	if err != nil {


### PR DESCRIPTION
adds the `-start` flag which will make a syscall to start the webby daemon in another process, detached from the parent.