### PR TITLE
reload on content change

### DIFF
--- a/daemon/proc.go
+++ b/daemon/proc.go
@@ -92,6 +92,20 @@ Start:
 
 			return false
 		}, CONFIG_PATH)
+
+		for _, filePath := range srv.ReqHandler.PathMap {
+			server.CallOnChange(func(signal server.FileChangeSignal) bool {
+				if signal == server.TimeModifiedChange || signal == server.SizeChange {
+					log.LogInfo("Site file change detected, reloading...")
+					signalChan <- ReloadSignal{}
+					return true
+				} else if signal == server.InitialReadError || signal == server.ReadError {
+					log.LogErr("Failed to read site file while checking for change (auto reload is on)")
+				}
+
+				return false
+			}, filePath)
+		}
 	}
 
 	sig := <-signalChan

--- a/server/config.go
+++ b/server/config.go
@@ -46,7 +46,8 @@ type ServerOptions struct {
 	// or "Info".
 	LogLevelRecord string
 
-	// Whether or not to check for changes in the config and reload automatically.
+	// Whether or not to check for changes in the config or site files and reload
+	// automatically.
 	AutoReload bool
 
 	// Paths that should be granted a dead response, can be used for fucking with


### PR DESCRIPTION
If auto reload is enabled in the configuration it will now reload on both config changes and changes to any hosted files.